### PR TITLE
Update zigbee2mqtt.class.php

### DIFF
--- a/modules/zigbee2mqtt/zigbee2mqtt.class.php
+++ b/modules/zigbee2mqtt/zigbee2mqtt.class.php
@@ -806,14 +806,14 @@ $this->getConfig();
 $gw=explode('/',$path)[0];
 
 
-if (strpos($path,'/0x')>0) {$msgtype='device_state';}
 if (strpos($path,'/bridge/state')>0) {$msgtype='bridge_state';}
-if (strpos($path,'/bridge/config')>0) {$msgtype='bridge_config';}
-if (strpos($path,'/bridge/networkmap/raw')>0) {$msgtype='raw_map';}
-if (strpos($path,'/bridge/networkmap')>0) {$msgtype='graphwiz';}
-if (strpos($path,'/bridge/networkmap/raw/nodes')>0) {$msgtype='rawnodes';}
+else if (strpos($path,'/bridge/config')>0) {$msgtype='bridge_config';}
+else if (strpos($path,'/bridge/networkmap/raw')>0) {$msgtype='raw_map';}
+else if (strpos($path,'/bridge/networkmap')>0) {$msgtype='graphwiz';}
+else if (strpos($path,'/bridge/networkmap/raw/nodes')>0) {$msgtype='rawnodes';}
+else if (strpos($path,'/bridge/log')>0) {$msgtype='log';}
+else {$msgtype='device_state';}
 
-if (strpos($path,'/bridge/log')>0) {$msgtype='log';}
 
 
 //if ($path=='zigbee2mqtt/bridge/log') {$msgtype=$json->{'type'};}


### PR DESCRIPTION
если friendly_name устройства сменен на юзерфрендли и не начинается на 0x - логи нормально не пишутся и не распределяются по устройствам.
В правке на 100% не уверен, но, у меня так всё стало ок.
Мне кажется, в условии и так перебраны все возможные варианты сообщений. Если не одно из них - значит, device_state. 
Поправьте, если ошибаюсь